### PR TITLE
feat: make TTS command (siid/aiid) configurable with per-model auto-detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ openclaw plugins install ./migpt-claw-1.0.0.tgz
 - `acknowledgeOnReceive`：收到消息时是否回复提示
 - `receiveMessage`：收到消息回复文案
 - `speakerControl`：音箱控制方式（`mina` 或 `miot`，默认 `mina`）
+- `ttsCommand`：MIoT TTS 播报动作坐标 `[siid, aiid]`（仅 `miot` 方式生效；不配置时自动探测，见下文）
 
 ### 音箱控制方式说明
 
@@ -70,6 +71,38 @@ openclaw plugins install ./migpt-claw-1.0.0.tgz
 - 如果默认 `mina` 方式无法正常工作，请尝试切换为 `miot`
 - 完整兼容性列表参考：[MiGPT 兼容性文档](https://github.com/idootop/mi-gpt/blob/main/docs/compatibility.md)
 - 建议自行编译测试以确定您的设备最佳配置
+
+### TTS 动作（siid/aiid）配置与自动探测
+
+`miot` 方式通过 MIoT 的 `intelligent-speaker` 服务发送 TTS 播报，但**不同型号该服务的 siid 不同**（例如多数老型号在 `siid=5`，而 `xiaomi.wifispeaker.x08c` 在 `siid=3`，其 `siid=5` 是麦克风服务）。发错 siid 时云端会静默拒绝（错误码如 `-704040005`），表现为"日志发送成功但音箱无声"。
+
+插件按以下优先级确定 TTS 动作：
+
+1. **显式配置** `ttsCommand: [siid, aiid]`（最高优先级）
+2. **按型号自动探测**：启动时查询 [miot-spec.org](https://miot-spec.org) 的设备 spec，定位 `intelligent-speaker` 服务下的 `play-text` 动作（等价于 `python3 -m miservice spec <model>`）
+3. **默认值** `[5, 1]`
+
+**配置示例**（x08c）：
+
+```json
+{
+  "channels": {
+    "migpt": {
+      "speakerControl": "miot",
+      "ttsCommand": [3, 1]
+    }
+  }
+}
+```
+
+**手动查询自己型号的 TTS 动作**：
+
+```bash
+pip install miservice
+python3 -m miservice spec xiaomi.wifispeaker.x08c
+# 在输出中找 intelligent-speaker 服务的 iid（即 siid），
+# 及其下 play-text 动作的 iid（即 aiid）
+```
 
 **特别说明**：当前项目未对所有小爱音箱型号进行全面测试，以上型号支持情况仅供参考。由于小爱音箱型号众多，不同型号可能存在差异，建议用户根据自身设备型号自行编译测试。
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -128,6 +128,7 @@ export function resolveMiAccount(
     timeout: accountConfig.timeout ?? migptCfg?.timeout,
     devices: accountConfig.devices ?? migptCfg?.devices ?? [],
     speakerControl: accountConfig.speakerControl ?? migptCfg?.speakerControl,
+    ttsCommand: accountConfig.ttsCommand ?? migptCfg?.ttsCommand,
   };
 
   // 检查是否已配置

--- a/src/mi/spec.ts
+++ b/src/mi/spec.ts
@@ -1,0 +1,74 @@
+import { Http } from '../utils/http.js';
+
+/** MIoT TTS 动作坐标：[siid, aiid] */
+export type TTSCommand = [siid: number, aiid: number];
+
+const SPEC_INSTANCES_URL = 'https://miot-spec.org/miot-spec-v2/instances';
+const SPEC_INSTANCE_URL = 'https://miot-spec.org/miot-spec-v2/instance';
+
+/**
+ * 已知型号的 TTS 动作回退表（在线探测失败时使用，欢迎 PR 补充）。
+ *
+ * 说明：不同型号的 intelligent-speaker 服务 siid 不同，
+ * 例如 x08c 在 siid=3，而部分 Redmi 型号在 siid=5。
+ */
+const KNOWN_TTS_COMMANDS: Record<string, TTSCommand> = {
+  'xiaomi.wifispeaker.x08c': [3, 1],
+};
+
+/** 默认 TTS 动作（多数老型号为 siid=5, aiid=1） */
+export const DEFAULT_TTS_COMMAND: TTSCommand = [5, 1];
+
+/**
+ * 根据设备型号自动探测 TTS 播报动作的 [siid, aiid]。
+ *
+ * 探测方式与 `python3 -m miservice spec <model>` 等价：
+ * 1. 从 miot-spec.org 公开接口按 model 查到 spec 实例的 type URN（取最高版本）；
+ * 2. 拉取完整 spec，定位 type 含 `:intelligent-speaker:` 的服务；
+ * 3. 在该服务的 actions 中定位 type 含 `:play-text:` 的动作；
+ * 4. 返回 [service.iid, action.iid]。
+ *
+ * 任一步失败则回退到 KNOWN_TTS_COMMANDS，仍未命中返回 undefined（由调用方决定默认值）。
+ */
+export async function detectTtsCommand(model?: string): Promise<TTSCommand | undefined> {
+  if (!model) {
+    return undefined;
+  }
+  try {
+    const instancesRes: any = await Http.get(SPEC_INSTANCES_URL, { status: 'released' });
+    const instances: any[] = instancesRes?.instances ?? [];
+    if (instancesRes?.isError || instances.length < 1) {
+      return KNOWN_TTS_COMMANDS[model];
+    }
+
+    const matched = instances.filter((i: any) => i?.model === model);
+    if (matched.length < 1) {
+      return KNOWN_TTS_COMMANDS[model];
+    }
+
+    // 同一型号可能有多个版本的 spec，取最高版本
+    const latest = matched.sort(
+      (a: any, b: any) => (b?.version ?? 0) - (a?.version ?? 0),
+    )[0];
+
+    const spec: any = await Http.get(SPEC_INSTANCE_URL, { type: latest.type });
+    if (spec?.isError) {
+      return KNOWN_TTS_COMMANDS[model];
+    }
+
+    const services: any[] = spec?.services ?? [];
+    const speakerService = services.find(
+      (s: any) => typeof s?.type === 'string' && s.type.includes(':intelligent-speaker:'),
+    );
+    const playText = (speakerService?.actions ?? []).find(
+      (a: any) => typeof a?.type === 'string' && a.type.includes(':play-text:'),
+    );
+
+    if (speakerService?.iid != null && playText?.iid != null) {
+      return [speakerService.iid, playText.iid];
+    }
+    return KNOWN_TTS_COMMANDS[model];
+  } catch {
+    return KNOWN_TTS_COMMANDS[model];
+  }
+}

--- a/src/service.ts
+++ b/src/service.ts
@@ -3,6 +3,7 @@ import { MIoT } from './mi/miot.js';
 import { getMiService } from './mi/common.js';
 import { assert, sleep } from './utils/parse.js';
 import { Debugger } from './utils/debug.js';
+import { detectTtsCommand, DEFAULT_TTS_COMMAND, type TTSCommand } from './mi/spec.js';
 
 export interface MiServiceConfig {
   /** 小米 ID（数字） */
@@ -17,6 +18,13 @@ export interface MiServiceConfig {
   timeout?: number;
   /** 音箱控制方式：mina/miot */
   speakerControl?: 'mina' | 'miot';
+  /**
+   * MIoT TTS 播报动作坐标 [siid, aiid]。
+   * 不配置时将根据设备型号自动探测（等价于查询 miot-spec.org 的设备 spec），
+   * 探测失败则回退到默认值 [5, 1]。
+   * 例如 xiaomi.wifispeaker.x08c 应为 [3, 1]。
+   */
+  ttsCommand?: TTSCommand;
 }
 
 class _MiService {
@@ -25,6 +33,7 @@ class _MiService {
   private _initialized = false;
   private _initializing = false;
   private _speakerControl: 'mina' | 'miot' = 'mina';
+  private _ttsCommand: TTSCommand = DEFAULT_TTS_COMMAND;
 
   /**
    * 使用 MIoT 发送 TTS 播报
@@ -34,13 +43,19 @@ class _MiService {
       console.warn('⚠️ MIoT 服务不可用');
       return false;
     }
+    const [siid, aiid] = this._ttsCommand;
     try {
-      // 使用 MIoT spec 调用 TTS 动作 (siid=5, aiid=1 是常见的 TTS 动作)
-      // 不同设备可能不同，需要根据设备 spec 调整
-      const result = await this.MiOT.doAction(5, 1, [text]);
+      const result = await this.MiOT.doAction(siid, aiid, [text]);
+      if (!result) {
+        // 云端接受请求 != 设备执行成功，明确提示便于排查
+        console.error(
+          `❌ MIoT TTS 播报未生效 (siid=${siid}, aiid=${aiid})，` +
+            '该型号的 play-text 动作可能位于其他 siid，请配置 ttsCommand 或查询设备 spec',
+        );
+      }
       return result;
     } catch (e: any) {
-      console.error('❌ MIoT TTS 失败:', e?.message || e);
+      console.error(`❌ MIoT TTS 失败 (siid=${siid}, aiid=${aiid}):`, e?.message || e);
       return false;
     }
   }
@@ -154,6 +169,29 @@ class _MiService {
             2,
           ),
         );
+      }
+
+      // 解析 MIoT TTS 播报动作：配置优先，其次按型号自动探测，最后回退默认值
+      if (this._speakerControl === 'miot') {
+        const model: string | undefined = (this.MiNA?.account as any)?.device?.model;
+        if (config.ttsCommand) {
+          this._ttsCommand = config.ttsCommand;
+          console.log(`🔊 使用配置的 TTS 动作: siid=${this._ttsCommand[0]}, aiid=${this._ttsCommand[1]}`);
+        } else {
+          const detected = await detectTtsCommand(model);
+          if (detected) {
+            this._ttsCommand = detected;
+            console.log(
+              `🔊 已按型号(${model ?? '未知'})自动探测 TTS 动作: siid=${detected[0]}, aiid=${detected[1]}`,
+            );
+          } else {
+            this._ttsCommand = DEFAULT_TTS_COMMAND;
+            console.warn(
+              `⚠️ 未能探测型号(${model ?? '未知'})的 TTS 动作，使用默认值 siid=${DEFAULT_TTS_COMMAND[0]}, aiid=${DEFAULT_TTS_COMMAND[1]}；` +
+                '如播报无声，请在配置中显式指定 ttsCommand',
+            );
+          }
+        }
       }
 
       this._initialized = true;


### PR DESCRIPTION
…etection

- Add ttsCommand config option ([siid, aiid]), account-level override supported
- Auto-detect play-text action from miot-spec.org by device model when unset
- Fall back to known-model table, then default [5, 1]
- Log explicit error when MIoT doAction returns false instead of silent failure
- Fixes silent TTS on xiaomi.wifispeaker.x08c (intelligent-speaker is siid=3)